### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,6 +10,7 @@
   ],
   "description" : "a perl6 binding for C implementation of the Kd-Tree Algorithm (https://github.com/jtsiomb/kdtree)",
   "name" : "Algorithm::KdTree",
+  "license" : "BSD-3-Clause",
   "perl" : "6.c",
   "provides" : {
     "Algorithm::KdTree" : "lib/Algorithm/KdTree.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license