### PR TITLE
Remove failing test

### DIFF
--- a/t/02-insert.t
+++ b/t/02-insert.t
@@ -9,11 +9,6 @@ use Algorithm::KdTree;
 
 {
     my $kdtree = Algorithm::KdTree.new(3);
-    dies-ok { $kdtree.insert([1,1,1]); }, "It shouldn't insert a Int array";
-}
-
-{
-    my $kdtree = Algorithm::KdTree.new(3);
     dies-ok { $kdtree.insert([1e0]); }, "It shouldn't insert a array having different dimension from the kd-tree's one";
 }
 


### PR DESCRIPTION
The test in question depends on `NativeHelpers::Array`'s `copy-to-carray`, which apparently now silently coerces values to the given type (if possible).

See also: https://github.com/rakudo/rakudo/issues/5584#issuecomment-2135774020